### PR TITLE
Adding .meta file because it causes errors in Unity when SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,3 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
-
-/[Rr]eleases/*.meta

--- a/Releases/com.apphud.unity.sdk-1.0.0.tgz.meta
+++ b/Releases/com.apphud.unity.sdk-1.0.0.tgz.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7d9fc30c9fc6486e81c53f0ca3544820
+timeCreated: 1718921456


### PR DESCRIPTION
Adding .meta file because it causes errors in Unity when SDK is added via GitHub link

`Asset Packages/com.apphud.unity.sdk/Releases/com.apphud.unity.sdk-1.0.0.tgz has no meta file, but it's in an immutable folder. The asset will be ignored.`