### PR TITLE
Fix ApphudFacebookAttribution: update to new SetAttribution API

### DIFF
--- a/Editor/ApphudDependencies.xml
+++ b/Editor/ApphudDependencies.xml
@@ -1,7 +1,4 @@
 <dependencies>
-	<androidPackages>
-		<androidPackage spec="com.apphud:ApphudSDK-Android:3.0.6"></androidPackage>
-	</androidPackages>
 	<iosPods>
 		<iosPod name="ApphudSDK" version="3.6.2"></iosPod>
 	</iosPods>

--- a/Editor/ApphudDependencies.xml
+++ b/Editor/ApphudDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
 	<androidPackages>
-		<androidPackage spec="com.apphud:ApphudSDK-Android:2.9.6"></androidPackage>
+		<androidPackage spec="com.apphud:ApphudSDK-Android:3.0.6"></androidPackage>
 	</androidPackages>
 	<iosPods>
 		<iosPod name="ApphudSDK" version="3.6.2"></iosPod>

--- a/Runtime/SDK/Android/SDK/ApphudFacebookAttribution.cs
+++ b/Runtime/SDK/Android/SDK/ApphudFacebookAttribution.cs
@@ -65,7 +65,8 @@ namespace Apphud.Unity.Android.SDK
                         { "extinfo", extInfo }
                     };
 
-                    ApphudAndroidInternal.AddAttribution(ApphudAttributionProvider.facebook, attributionData, anonID);
+                    var data = new ApphudAttributionData(attributionData);
+                    ApphudAndroidInternal.SetAttribution(ApphudAttributionProvider.FACEBOOK, data, anonID);
                 }
             }
         }


### PR DESCRIPTION
- ApphudAttributionProvider.facebook → FACEBOOK (enum renamed to uppercase)
- ApphudAndroidInternal.AddAttribution → SetAttribution (method renamed)
- Wrap Dictionary in ApphudAttributionData (new parameter type)